### PR TITLE
2to3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-  - "3.7"
+  - "3.6"
 
 install:
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-  - "2.7"
+  - "3.7"
 
 install:
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     directories:
     - /tmp/proto3.3.2
 before_install:
+    - pip install -U pip
     - sudo apt-get update -qq
     - sudo apt-get install graphviz
     - bash tools/travis-install-protoc.sh 3.3.2

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -1,10 +1,10 @@
 Documention
 !!!!!!!!!!!
 
-This directory contains source and tools to build the GA4GH schemas
+This directory contains source and tools to build the CanDIG schemas
 documentation.
 
-The `GA4GH schemas documentation
+The `CanDIG schemas documentation
 <http://ga4gh-schemas.readthedocs.org/>`_ is built automatically by
 Read the Docs, typically within two minutes of a commit to the master
 branch.

--- a/doc/source/_static/assaymetadata_schema.svg
+++ b/doc/source/_static/assaymetadata_schema.svg
@@ -64,7 +64,7 @@ x2="180"
 y2="960"
 />
 <rect x="20" y="980" width="160" height="25" />
-<text transform="translate(40 980)" ><tspan x="0" dy="18" font-weight="900">OtherGA4GHobject</tspan>
+<text transform="translate(40 980)" ><tspan x="0" dy="18" font-weight="900">OtherCanDIGobject</tspan>
 </text>
 <rect x="20" y="1005" width="160" height="82" />
 <text transform="translate(40 1005)" ><tspan  style="font-weight: 900; fill: red;" 	x="0" dy="18">id</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">biosampleId</tspan><tspan 	x="0" dy="18">datasetId</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">experimentId</tspan></text>

--- a/doc/source/_static/biometadata_schema.svg
+++ b/doc/source/_static/biometadata_schema.svg
@@ -54,7 +54,7 @@ x2="180"
 y2="184"
 />
 <rect x="20" y="204" width="160" height="25" />
-<text transform="translate(40 204)" ><tspan x="0" dy="18" font-weight="900">OtherGA4GHobject</tspan>
+<text transform="translate(40 204)" ><tspan x="0" dy="18" font-weight="900">OtherCanDIGobject</tspan>
 </text>
 <rect x="20" y="229" width="160" height="46" />
 <text transform="translate(40 229)" ><tspan  style="font-weight: 900; fill: red;" 	x="0" dy="18">id</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">biosampleId</tspan></text>

--- a/doc/source/_static/metadata_schema.svg
+++ b/doc/source/_static/metadata_schema.svg
@@ -64,7 +64,7 @@ x2="180"
 y2="870"
 />
 <rect x="20" y="890" width="160" height="25" />
-<text transform="translate(40 890)" ><tspan x="0" dy="18" font-weight="900">OtherGA4GHobject</tspan>
+<text transform="translate(40 890)" ><tspan x="0" dy="18" font-weight="900">OtherCanDIGobject</tspan>
 </text>
 <rect x="20" y="915" width="160" height="82" />
 <text transform="translate(40 915)" ><tspan  style="font-weight: 900; fill: red;" 	x="0" dy="18">id</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">biosampleId</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">datasetId</tspan><tspan  font-style="italic" style="" 	x="0" dy="18">experimentId</tspan></text>

--- a/doc/source/_static/network.svg
+++ b/doc/source/_static/network.svg
@@ -223,7 +223,7 @@
     <tspan x="123" y="988">hostnames and both list each other.</tspan>
   </text>
   <text font-size="20.4216" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="560" y="-53">
-    <tspan x="560" y="-53">GA4GH Network Diagram</tspan>
+    <tspan x="560" y="-53">CanDIG Network Diagram</tspan>
   </text>
   <text font-size="20.4216" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="617" y="-19">
     <tspan x="617" y="-19">March 7, 2017</tspan>
@@ -303,7 +303,7 @@
     <tspan x="141" y="155.5">the Genomics API.</tspan>
     <tspan x="141" y="171.5"></tspan>
     <tspan x="141" y="187.5">It is our goal to make beacon the discovery</tspan>
-    <tspan x="141" y="203.5">layer for further GA4GH inquiry.</tspan>
+    <tspan x="141" y="203.5">layer for further CanDIG inquiry.</tspan>
   </text>
   <text font-size="12.8" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="352.8" y="646.6">
     <tspan x="352.8" y="646.6"></tspan>

--- a/doc/source/api/apidesign_intro.rst
+++ b/doc/source/api/apidesign_intro.rst
@@ -91,14 +91,14 @@ For the Dataset schema definition see the `Metadata schema
 Unresolved Issues
 @@@@@@@@@@@@@@@@@
 
-* Is the GA4GH object design a conceptual data model that must be
+* Is the CanDIG object design a conceptual data model that must be
   followed or only containers for data exchange.  If they are
   containers, where is the conceptual data model defined?
 
-* Are GA4GH objects idempotent?  In particular, can one obtain an
+* Are CanDIG objects idempotent?  In particular, can one obtain an
   object with a subset of it's fields?
 
-* Is object life-cycle semantics in the scope of GA4GH API? Which
+* Is object life-cycle semantics in the scope of CanDIG API? Which
   objects are immutable and which are mutable?  If objects are
   mutable, how does one know they have changed?  How does one protect
   against changes while using the objects over a given time-frame?

--- a/doc/source/api/apigoals_intro.rst
+++ b/doc/source/api/apigoals_intro.rst
@@ -5,9 +5,9 @@ API Goals
 !!!!!!!!!
 
 
-* From the `GA4GH DWG <http://ga4gh.org/#/documentation>`_ site:
+* From the `CanDIG DWG <http://ga4gh.org/#/documentation>`_ site:
 
-    The Global Alliance for Genomics and Health (GA4GH) Genomics [API]
+    The Global Alliance for Genomics and Health (CanDIG) Genomics [API]
     will allow the interoperable exchange of genomic information
     across multiple organizations and on multiple platforms. This is a
     freely available open standard for interoperability, that uses

--- a/doc/source/api/apigoals_intro.rst
+++ b/doc/source/api/apigoals_intro.rst
@@ -5,9 +5,9 @@ API Goals
 !!!!!!!!!
 
 
-* From the `CanDIG DWG <http://ga4gh.org/#/documentation>`_ site:
+* From the `GA4GH DWG <http://ga4gh.org/#/documentation>`_ site:
 
-    The Global Alliance for Genomics and Health (CanDIG) Genomics [API]
+    The Global Alliance for Genomics and Health (GA4GH) Genomics [API]
     will allow the interoperable exchange of genomic information
     across multiple organizations and on multiple platforms. This is a
     freely available open standard for interoperability, that uses

--- a/doc/source/api/assaymetadata.rst
+++ b/doc/source/api/assaymetadata.rst
@@ -10,7 +10,7 @@
 AssayMetadata: *Experiment* Object
 **********************************
 
-Experiment in the GA4GH Schema
+Experiment in the CanDIG Schema
 ------------------------------
 
 
@@ -37,7 +37,7 @@ Attribute             Notes
 AssayMetadata: *Analysis* Object
 ********************************
 
-Analysis in the GA4GH Schema
+Analysis in the CanDIG Schema
 ------------------------------
 
 

--- a/doc/source/api/biometadata.rst
+++ b/doc/source/api/biometadata.rst
@@ -10,10 +10,10 @@
 BioMetadata: *Biosample* Object
 *******************************
 
-Biosample in the GA4GH Schema
+Biosample in the CanDIG Schema
 ------------------------------
 
-The majority of use cases of GA4GH
+The majority of use cases of CanDIG
 schema compatible resources will serve to facilitate the retrieval of *molecular
 features* (DNA sequence variations, gene expression, protein variants) measured
 by performing *experimental* (whole genome sequencing, expression arrays, mass
@@ -22,7 +22,7 @@ preparation of target molecules (e.g. DNA, RNA) which has been extracted from a
 *biological sample* (e.g. tissue biopsy, single cell from FACS,
 environmental sample).
 
-In the GA4GH schema, a *Biosample* represents the main "biological
+In the CanDIG schema, a *Biosample* represents the main "biological
 item" against which molecular variants are referenced.
 
 Biosample attributes
@@ -50,10 +50,10 @@ Attribute             Notes
 BioMetadata: *Individual* Object
 ********************************
 
-Individual in the GA4GH Schema
+Individual in the CanDIG Schema
 ------------------------------
 
-An *Individual* is a GA4GH data object representing a biological instance
+An *Individual* is a CanDIG data object representing a biological instance
 (most commonly a human being or other individual organism) on whose *Biosamples*
 experimental analyses are performed.
 

--- a/doc/source/api/genotypephenotype.rst
+++ b/doc/source/api/genotypephenotype.rst
@@ -8,7 +8,7 @@ Summary
 =======
 
 This API allows users to search for genotype-phenotype
-associations in a GA4GH datastore. The user can search for associations
+associations in a CanDIG datastore. The user can search for associations
 by building queries composed of features, phenotypes, and/or evidence
 terms. The API is designed to accommodate search terms specified as
 either a string, external identifier, ontology identifier, or as an
@@ -37,7 +37,7 @@ G2P servers are planned to be implemented in three different contexts:
    :alt: image
 
 
--  Coupled with sequence annotation and GA4GH datasets. Clients will
+-  Coupled with sequence annotation and CanDIG datasets. Clients will
    want implementation specific featureId/genotypeId to match and
    integrate with the rest of the APIs.
 
@@ -79,7 +79,7 @@ by the Monarch project was the source of Evidence.
    :alt: image
 
 
-Intent: The GA4GH Ontology schema provides structures for unambiguous
+Intent: The CanDIG Ontology schema provides structures for unambiguous
 references to ontological concepts and/or controlled vocabularies
 within Protocol Buffers. The structures provided are not intended for
 de novo modeling of ontologies, or representing complete ontologies
@@ -127,7 +127,7 @@ Entity Searches
 
    -  Given a SearchFeaturesRequest, return matching *features* in the
       ``current 'omics dataset``. Intended for sequence annotation and
-      GA4GH datasets.
+      CanDIG datasets.
 
 -  ``/phenotypes/search``
 
@@ -145,7 +145,7 @@ Association Search
 Usage
 -----
 
-1. As a GA4GH client, use entity queries for the genotypes and
+1. As a CanDIG client, use entity queries for the genotypes and
    phenotypes you are interested in.
 2. Create an association search using the entity identifiers from step
    1.

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -99,7 +99,7 @@ with genomic features.
 Network
 @@@@@@@
 
-GA4GH services can communicate with each other about the services they offer
+CanDIG services can communicate with each other about the services they offer
 over network protocols. This includes the Peer Service.
 
 .. toctree::

--- a/doc/source/api/metadata.rst
+++ b/doc/source/api/metadata.rst
@@ -16,7 +16,7 @@ Goals and Scope
 * a schema of how objects relate to each other
 
 The metadata API provides information on the primary data objects
-available via the GA4GH API, and facilities to organize primary data
+available via the CanDIG API, and facilities to organize primary data
 objects.
 
 The current metadata API is immature and will evolve in future.
@@ -28,7 +28,7 @@ Metadata Records
 :ref:`Dataset<metadata_dataset>`
 ====================================
 
-All GA4GH data objects are part of a *dataset*. A dataset is a
+All CanDIG data objects are part of a *dataset*. A dataset is a
 data-provider-specified collection of related data of multiple types.
 Logically, it's akin to a folder, where it's up to the provider what
 goes into the folder. Individual data objects are linked by
@@ -116,7 +116,7 @@ They are indicated with a leading "P", followed by unit delimited
 quantifiers. A leading "T" is required before the start of the time components.
 Durations do not have to be normalized; "PT50H" is equally valid as "P2T2H".
 A frequent use of durations in biomedical data resources are *age* values,
-e.g. "age at diagnosis"; but also "progression free survival", "followup" or "time to recurrence" (these are descriptive labels, which do not necessarily represent GA4GH schema use).
+e.g. "age at diagnosis"; but also "progression free survival", "followup" or "time to recurrence" (these are descriptive labels, which do not necessarily represent CanDIG schema use).
 
 **Examples**
 
@@ -165,7 +165,7 @@ Dataset
 
 .. _metadata_dataset:
 
-All GA4GH data objects are part of a *dataset*. A dataset is a
+All CanDIG data objects are part of a *dataset*. A dataset is a
 data-provider-specified collection of related data of multiple types.
 Logically, it's akin to a folder, where it's up to the provider what
 goes into the folder. Individual data objects are linked by

--- a/doc/source/api/network.rst
+++ b/doc/source/api/network.rst
@@ -2,11 +2,11 @@
 
 
 *************************
-Connecting GA4GH Services
+Connecting CanDIG Services
 *************************
 
 
-The GA4GH aims to create an easy to implement network of Genomics data
+The CanDIG aims to create an easy to implement network of Genomics data
 services. To achieve this end, the protocol presents some message, endpoints,
 and methods that are dedicated to communicating about a service's status
 when establishing peers.
@@ -34,7 +34,7 @@ Use Cases
    She first announces her service to Bob and then adds Bob’s service to
    her list of peers.
 -  Alice would like to get a list of all the available datasets on a
-   GA4GH network. She first requests the dataset from a known member of
+   CanDIG network. She first requests the dataset from a known member of
    the network. She then requests that service’s list of peers. She then
    requests the list of datasets from each peer in the peer list. By
    recursively following peer lists she can list all the datasets on the
@@ -50,7 +50,7 @@ Ad-hoc private networks can be established between peers, as well as hub and
 spoke models.
 
 Institutions may choose to take advantage of the Peer Service to tier
-services. This is done by presenting a service to the public on the GA4GH
+services. This is done by presenting a service to the public on the CanDIG
 network that performs aggregations of data on underlying peers. These peers
 only expose their services to the aggregation service.
 
@@ -84,7 +84,7 @@ using a list of known good peers.
 Public Initial Peers
 ********************
 
-The GA4GH attempts to bootstrap this network by maintaining the latest
+The CanDIG attempts to bootstrap this network by maintaining the latest
 released network protocol at http://1kgenomes.ga4gh.org . However, the
 process of evaluating announcements requires human curation, so do not expect
 your peer to be listed immediately.
@@ -125,7 +125,7 @@ Listing Peers
 
 Each service, in addition to receiving announcements about the presence of
 other peers, shares its list of peers at the ``peers/list`` endpoint. This
-list can be paged through similar to other GA4GH endpoints. Each entry
+list can be paged through similar to other CanDIG endpoints. Each entry
 in the `ListPeersResponse
 <../schemas/peer_service.proto.html#protobuf.ListPeersResponse>`_ includes a URL
 to a possible peer. It is up to individual services to maintain

--- a/doc/source/api/network.rst
+++ b/doc/source/api/network.rst
@@ -84,7 +84,7 @@ using a list of known good peers.
 Public Initial Peers
 ********************
 
-The CanDIG attempts to bootstrap this network by maintaining the latest
+The GA4GH attempts to bootstrap this network by maintaining the latest
 released network protocol at http://1kgenomes.ga4gh.org . However, the
 process of evaluating announcements requires human curation, so do not expect
 your peer to be listed immediately.

--- a/doc/source/api/variants.rst
+++ b/doc/source/api/variants.rst
@@ -53,7 +53,7 @@ something in common:
       information about what differences were found.
 
 The following diagram shows the relationship of these four entities to
-each other and to other GA4GH API entities. It shows which entities
+each other and to other CanDIG API entities. It shows which entities
 contain other entities (such as :protobuf:message:`VariantSetMetadata`),
 and which contain IDs that can be used to get information from other
 entities (such as :protobuf:message:`Variant`'s ``variantSetId``). The

--- a/doc/source/appendix/json_intro.rst
+++ b/doc/source/appendix/json_intro.rst
@@ -6,13 +6,13 @@ The JSON Format
 
 JSON, or JavaScript Object Notation, is officially defined `here <http://json.org/example>`_. It is the standard data interchange format for web APIs.
 
-The GA4GH Web API uses a JSON wire protocol, exchanging JSON representations of the objects defined in its Protocol Buffers schemas. More information on the schemas is available in :ref:`proto`; basically, the Protocol Buffers type definitions say what attributes any given JSON object ought to have, and what ought to be stored in each of them.
+The CanDIG Web API uses a JSON wire protocol, exchanging JSON representations of the objects defined in its Protocol Buffers schemas. More information on the schemas is available in :ref:`proto`; basically, the Protocol Buffers type definitions say what attributes any given JSON object ought to have, and what ought to be stored in each of them.
 
 ------------------------
-GA4GH JSON Serialization
+CanDIG JSON Serialization
 ------------------------
 
-The GA4GH web APIs use Protocol Buffers IDL to define their schemas, and use the associated Google Protocol Buffers JSON serialization libraries. Notice that the Protocol Buffers IDL uses snake case, while the on-the-wire protocol is in camel case.
+The CanDIG web APIs use Protocol Buffers IDL to define their schemas, and use the associated Google Protocol Buffers JSON serialization libraries. Notice that the Protocol Buffers IDL uses snake case, while the on-the-wire protocol is in camel case.
 
 ---------------------
 Serialization example

--- a/doc/source/appendix/ontologies.rst
+++ b/doc/source/appendix/ontologies.rst
@@ -1,13 +1,13 @@
 .. _metadata_ontologies:
 
-Use of Ontologies in GA4GH API
+Use of Ontologies in CanDIG API
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Examples for OntologyTerm use
 -----------------------------
 
 * Info: Ontogenesis blog
-* Info: Working implementation of the GA4GH docsystem's Ontologies document
+* Info: Working implementation of the CanDIG docsystem's Ontologies document
 
 
 Why should we use an ontology term?
@@ -33,7 +33,7 @@ which may have a varying depth, the executioner of the query has to judge
 about the optimal scope of the returned data.
 
 
-What is the minimum attribute requirement for  OntologyTerm in GA4GH?
+What is the minimum attribute requirement for  OntologyTerm in CanDIG?
 =====================================================================
 
 Conceptually (and consistent with the metadata branch)

--- a/doc/source/appendix/proto_intro.rst
+++ b/doc/source/appendix/proto_intro.rst
@@ -5,26 +5,26 @@ Google Protocol Buffers
 ***********************
 
 -------------------------------------------------------
-What does the GA4GH web API take from Protocol Buffers?
+What does the CanDIG web API take from Protocol Buffers?
 -------------------------------------------------------
 
-The GA4GH web API uses the Google Protocol Buffers language and JSON serialization libraries.
+The CanDIG web API uses the Google Protocol Buffers language and JSON serialization libraries.
 
-The GA4GH web API presents a simple HTTP(S) and JSON interface to clients. It does **not** use Protocol Buffers's binary serialization format.
+The CanDIG web API presents a simple HTTP(S) and JSON interface to clients. It does **not** use Protocol Buffers's binary serialization format.
 
 -------------------------------------------------------
-How does the GA4GH web API use Protocol Buffer schemas?
+How does the CanDIG web API use Protocol Buffer schemas?
 -------------------------------------------------------
 
-GA4GH web API objects, including both the data objects actually exchanged and the control messages requesting and returning those objects, are defined in Protocol Buffers.
+CanDIG web API objects, including both the data objects actually exchanged and the control messages requesting and returning those objects, are defined in Protocol Buffers.
 
 The full documentation for the Protocol buffers language can be found `here <https://developers.google.com/protocol-buffers/docs/proto3>`_.
 
 ------------------------------------------------
-How does the GA4GH Web API use Protocol Buffers?
+How does the CanDIG Web API use Protocol Buffers?
 ------------------------------------------------
 
-The GA4GH web API schemas are broken up into multiple proto files, which reference each other. Each file defines a number of message types, grouped into a "protocol" that defines a facet of the API. Mostly, the files come in pairs: a normal proto file defining the types representing actual data, and a "methods" proto file defining the control messages to be sent back and forth to query and exchange the representational types, and the URLs associated with various operations.
+The CanDIG web API schemas are broken up into multiple proto files, which reference each other. Each file defines a number of message types, grouped into a "protocol" that defines a facet of the API. Mostly, the files come in pairs: a normal proto file defining the types representing actual data, and a "methods" proto file defining the control messages to be sent back and forth to query and exchange the representational types, and the URLs associated with various operations.
 
 Each type has a leading comment documenting its purpose, and each field in the type has a description. These are included in the automatically generated API documentation.
 

--- a/doc/source/appendix/swagger.rst
+++ b/doc/source/appendix/swagger.rst
@@ -3,9 +3,9 @@
 Generating API Definitions
 @@@@@@@@@@@@@@@@@@@@@@@@@@
 
-There has been an effort to standardize the methods for generating HTTP API descriptions that allow developers to rapidly develop gateways into their data. Since the GA4GH schemas are defined using Google Protocol Buffers IDL, it is possible to use this definition to generate documentation and code.
+There has been an effort to standardize the methods for generating HTTP API descriptions that allow developers to rapidly develop gateways into their data. Since the CanDIG schemas are defined using Google Protocol Buffers IDL, it is possible to use this definition to generate documentation and code.
 
-In this document we will generate swagger definitions for the GA4GH API using a plugin for the `protoc` compiler. For more on installing the protocol buffers compiler see INSTALL.rst.
+In this document we will generate swagger definitions for the CanDIG API using a plugin for the `protoc` compiler. For more on installing the protocol buffers compiler see INSTALL.rst.
 
 Installing Prerequisites
 ------------------------
@@ -66,4 +66,4 @@ Using the online interface it is possible to export both client and server stubs
 
   $ swagger-codegen generate -i target/swagger/ga4gh/read_service.swagger.json -l python -o ga4gh-reads-client
 
-This will create a directory `ga4gh-reads-client` that includes most of the boilerplate, including README, `.gitignore`, etc., required to create a GA4GH client. This client can then be customized, modified, and imported into other projects for use.
+This will create a directory `ga4gh-reads-client` that includes most of the boilerplate, including README, `.gitignore`, etc., required to create a CanDIG client. This client can then be customized, modified, and imported into other projects for use.

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -123,7 +123,7 @@ Schema Release ``v0.6.0a5``
 Changes to ``ga4gh/schemas`` ``master`` branch since version
 ``v0.6.0a4`` (Apr 7, 2016)
 
-First Protocol Buffers (protobuf v3.0.0) version of the GA4GH API. Same
+First Protocol Buffers (protobuf v3.0.0) version of the CanDIG API. Same
 set of features (messages, endpoints) as previous alpha release.
 
 IMPORTANT: The switch from AVRO to protobuf in this pre-release will

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,8 +87,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'CanDIG Schemas'
-copyright = '2015, Global Alliance for Genomics and Health'
-author = 'Global Alliance for Genomics and Health'
+copyright = ''
+author = 'GA4GH, CanDIG Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# GA4GH Schemas documentation build configuration file, created by
+# CanDIG Schemas documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul  2 16:00:07 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -86,7 +86,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'GA4GH Schemas'
+project = 'CanDIG Schemas'
 copyright = '2015, Global Alliance for Genomics and Health'
 author = 'Global Alliance for Genomics and Health'
 
@@ -262,7 +262,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'ga4ghschemas.tex', 'GA4GH Schemas Documentation',
+  (master_doc, 'ga4ghschemas.tex', 'CanDIG Schemas Documentation',
    'Jeltje van Baren', 'manual'),
 ]
 
@@ -292,7 +292,7 @@ latex_logo = "_static/logo_ga.png"
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ga4ghschemas', 'GA4GH Schemas Documentation',
+    (master_doc, 'ga4ghschemas', 'CanDIG Schemas Documentation',
      [author], 1)
 ]
 
@@ -306,7 +306,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'ga4ghschemas', 'GA4GH Schemas Documentation',
+  (master_doc, 'ga4ghschemas', 'CanDIG Schemas Documentation',
    author, 'ga4ghschemas', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,7 +53,7 @@ for root, dirs, files in os.walk(schema_dir):
         fullpath = os.path.join(root, f)
         json_file = f + ".json"
         cmd = "protoc --proto_path %s --plugin=protoc-gen-custom=%s --custom_out=%s %s" % (base_dir, os.path.join(sphinx_path, "protobuf-json-docs.py"), json_dir, fullpath)
-        print cmd
+        print(cmd)
         subprocess.check_call(cmd, shell=True)
 
 for root, dirs, files in os.walk(json_dir):
@@ -61,14 +61,14 @@ for root, dirs, files in os.walk(json_dir):
         if not f.endswith(".json"):
             continue
         cmd = "python %s %s/%s schemas/" %(os.path.join(sphinx_path, "protodoc2rst.py"), root, f)
-        print cmd
+        print(cmd)
         subprocess.check_call(cmd, shell=True)
 
 # Generate the svg of the schema UML diagram
 ga4gh_schema_dir = os.path.join(schema_dir, "candig")
 uml_dir = os.path.join("_build", "generated_images")
 cmd = "protoc --proto_path %s --plugin=protoc-gen-custom=%s --custom_out=%s %s" % (base_dir, os.path.join(sphinx_path, "protobuf-uml.py"), uml_dir, os.path.join(ga4gh_schema_dir, "*.proto"))
-print cmd
+print(cmd)
 subprocess.check_call(cmd, shell=True)
 
 # Add any paths that contain templates here, relative to this directory.
@@ -86,9 +86,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'GA4GH Schemas'
-copyright = u'2015, Global Alliance for Genomics and Health'
-author = u'Global Alliance for Genomics and Health'
+project = 'GA4GH Schemas'
+copyright = '2015, Global Alliance for Genomics and Health'
+author = 'Global Alliance for Genomics and Health'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -262,8 +262,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'ga4ghschemas.tex', u'GA4GH Schemas Documentation',
-   u'Jeltje van Baren', 'manual'),
+  (master_doc, 'ga4ghschemas.tex', 'GA4GH Schemas Documentation',
+   'Jeltje van Baren', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -292,7 +292,7 @@ latex_logo = "_static/logo_ga.png"
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ga4ghschemas', u'GA4GH Schemas Documentation',
+    (master_doc, 'ga4ghschemas', 'GA4GH Schemas Documentation',
      [author], 1)
 ]
 
@@ -306,7 +306,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'ga4ghschemas', u'GA4GH Schemas Documentation',
+  (master_doc, 'ga4ghschemas', 'GA4GH Schemas Documentation',
    author, 'ga4ghschemas', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,7 +240,7 @@ html_show_sphinx = False
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ga4ghschemasdoc'
+htmlhelp_basename = 'candigschemasdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -262,7 +262,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'ga4ghschemas.tex', 'CanDIG Schemas Documentation',
+  (master_doc, 'candigschemas.tex', 'CanDIG Schemas Documentation',
    'Jeltje van Baren', 'manual'),
 ]
 
@@ -292,7 +292,7 @@ latex_logo = "_static/logo_ga.png"
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ga4ghschemas', 'CanDIG Schemas Documentation',
+    (master_doc, 'candigschemas', 'CanDIG Schemas Documentation',
      [author], 1)
 ]
 
@@ -306,8 +306,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'ga4ghschemas', 'CanDIG Schemas Documentation',
-   author, 'ga4ghschemas', 'One line description of project.',
+  (master_doc, 'candigschemas', 'CanDIG Schemas Documentation',
+   author, 'candigschemas', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/doc/source/includes/glossary/variants.rst
+++ b/doc/source/includes/glossary/variants.rst
@@ -7,7 +7,7 @@ Genetic variants are differences in the genome sequence from one
 individual to the next. Such variation can manifest at different
 scales, from small changes affecting just one or a few DNA base pairs,
 to copy number variations of whole exons or genes, to large structural
-variations affecting megabases or more. The GA4GH Variants schema
+variations affecting megabases or more. The CanDIG Variants schema
 focuses on small variants for now, because there's less consensus on
 how to represent the larger kinds of variation.
 
@@ -71,7 +71,7 @@ There remain some outstanding challenges with this model of small
 variants. For example, the same edit to the reference sequence can be
 represented in multiple ways. There are also different ways to
 represent clusters of alleles that affect overlapping but non-equal
-portions of the reference. The GA4GH doesn't yet prescribe resolutions
+portions of the reference. The CanDIG doesn't yet prescribe resolutions
 to these ambiguities, and different conventions are used in practice.
 
 (TODO possible additional/advanced topics: homozygous ref vs. no-call;

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,10 +2,10 @@
 
 ----
 
-GA4GH Genomics API
+CanDIG Genomics API
 !!!!!!!!!!!!!!!!!!
 
-The `GA4GH`_ API attempts to gather together protocols and data models useful
+The `CanDIG`_ API attempts to gather together protocols and data models useful
 for genomics data interchange. It offers protocols that can be
 implemented over existing Genomics data stores to make these results more
 easily discovered, shared, and replicated.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -1,8 +1,8 @@
-Installing the GA4GH Schemas
+Installing the CanDIG Schemas
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 The schemas are documents (text files) that formally describe the
-messages that pass between GA4GH servers and clients, which we
+messages that pass between CanDIG servers and clients, which we
 also refer to collectively as "the API." The schemas are written in a
 language called `Protocol Buffers 3 <https://developers.google.com/protocol-buffers/>`__.
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -33,7 +33,7 @@ Wikipedia also has good overviews of `bioinformatics <https://en.wikipedia.org/w
 and `DNA sequencing <https://en.wikipedia.org/wiki/DNA_sequencing>`_
 
 
-The GA4GH web API
+The CanDIG web API
 @@@@@@@@@@@@@@@@@
 
 This API was created to enable researchers to better access and
@@ -42,7 +42,7 @@ complete BAM files or whole genome annotations, the API allows
 retrieval of information on, for instance, single genes or genomic
 regions.
 
-For a full list of the GA4GH API goals, see :ref:`apigoals`
+For a full list of the CanDIG API goals, see :ref:`apigoals`
 
 
 Schemas and formats
@@ -55,7 +55,7 @@ actually representing pieces of genomics data.
 
 The schemas are written in Protocol Buffers Interface Description
 Language (extension .proto). For more details on Protocol Buffers
-and how it is used in the GA4GH APIs, see :ref:`proto`.
+and how it is used in the CanDIG APIs, see :ref:`proto`.
 
 Here is an example schema definition for a Variant (with comments
 removed)::
@@ -75,7 +75,7 @@ removed)::
     repeated Call calls = 12;
   }
 
-On the wire, the GA4GH web API takes the form of a client and a server
+On the wire, the CanDIG web API takes the form of a client and a server
 exchanging JSON-serialized objects over HTTP or HTTPS. For more
-details on JSON, including how the GA4GH web API serializes and
+details on JSON, including how the CanDIG web API serializes and
 deserializes Protocol Buffers objects in JSON, see :ref:`json`.

--- a/python/candig/__init__.py
+++ b/python/candig/__init__.py
@@ -1,8 +1,8 @@
 """
 GA4GH schemas
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 __import__('pkg_resources').declare_namespace(__name__)

--- a/python/candig/__init__.py
+++ b/python/candig/__init__.py
@@ -2,7 +2,4 @@
 GA4GH schemas
 """
 
-
-
-
 __import__('pkg_resources').declare_namespace(__name__)

--- a/python/candig/schemas/hacks/googhack.py
+++ b/python/candig/schemas/hacks/googhack.py
@@ -2,9 +2,6 @@
 Hack for getting a handle to the top-level google module, etc.
 """
 
-
-
-
 import google.protobuf.json_format as json_format
 import google.protobuf.message as message
 import google.protobuf.struct_pb2 as struct_pb2

--- a/python/candig/schemas/hacks/googhack.py
+++ b/python/candig/schemas/hacks/googhack.py
@@ -1,9 +1,9 @@
 """
 Hack for getting a handle to the top-level google module, etc.
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import google.protobuf.json_format as json_format
 import google.protobuf.message as message

--- a/python/candig/schemas/pb.py
+++ b/python/candig/schemas/pb.py
@@ -2,9 +2,6 @@
 Utility methods for handling protocol buffer
 """
 
-
-
-
 DEFAULT_STRING = ''
 DEFAULT_INT = 0
 

--- a/python/candig/schemas/pb.py
+++ b/python/candig/schemas/pb.py
@@ -1,9 +1,9 @@
 """
 Utility methods for handling protocol buffer
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 DEFAULT_STRING = ''
 DEFAULT_INT = 0

--- a/python/candig/schemas/protocol.py
+++ b/python/candig/schemas/protocol.py
@@ -1,9 +1,9 @@
 """
 Definitions of the GA4GH protocol types.
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import datetime
 import json
@@ -12,41 +12,42 @@ import sys
 import array
 import base64
 
-from _protocol_version import version  # noqa
-from candig.common_pb2 import *  # noqa
-from candig.metadata_pb2 import *  # noqa
-from candig.metadata_service_pb2 import *  # noqa
-from candig.read_service_pb2 import *  # noqa
-from candig.reads_pb2 import *  # noqa
-from candig.reference_service_pb2 import *  # noqa
-from candig.references_pb2 import *  # noqa
-from candig.variant_service_pb2 import *  # noqa
-from candig.genotype_service_pb2 import *  # noqa
-from candig.variants_pb2 import *  # noqa
-from candig.allele_annotations_pb2 import *  # noqa
-from candig.allele_annotation_service_pb2 import *  # noqa
-from candig.sequence_annotations_pb2 import *  # noqa
-from candig.sequence_annotation_service_pb2 import *  # noqa
-from candig.bio_metadata_pb2 import *  # noqa
-from candig.bio_metadata_service_pb2 import *  # noqa
-from candig.genotype_phenotype_pb2 import *  # noqa
-from candig.genotype_phenotype_service_pb2 import *  # noqa
-from candig.rna_quantification_pb2 import *  # noqa
-from candig.rna_quantification_service_pb2 import *  # noqa
-from candig.peer_service_pb2 import *  # noqa
+from ._protocol_version import version  # noqa
+from .candig.common_pb2 import *  # noqa
+from .candig.metadata_pb2 import *  # noqa
+from .candig.metadata_service_pb2 import *  # noqa
+from .candig.read_service_pb2 import *  # noqa
+from .candig.reads_pb2 import *  # noqa
+from .candig.reference_service_pb2 import *  # noqa
+from .candig.references_pb2 import *  # noqa
+from .candig.variant_service_pb2 import *  # noqa
+from .candig.genotype_service_pb2 import *  # noqa
+from .candig.variants_pb2 import *  # noqa
+from .candig.allele_annotations_pb2 import *  # noqa
+from .candig.allele_annotation_service_pb2 import *  # noqa
+from .candig.sequence_annotations_pb2 import *  # noqa
+from .candig.sequence_annotation_service_pb2 import *  # noqa
+from .candig.bio_metadata_pb2 import *  # noqa
+from .candig.bio_metadata_service_pb2 import *  # noqa
+from .candig.genotype_phenotype_pb2 import *  # noqa
+from .candig.genotype_phenotype_service_pb2 import *  # noqa
+from .candig.rna_quantification_pb2 import *  # noqa
+from .candig.rna_quantification_service_pb2 import *  # noqa
+from .candig.peer_service_pb2 import *  # noqa
 
 # METADATA
-from candig.clinical_metadata_pb2 import *  # noqa
-from candig.clinical_metadata_service_pb2 import *  # noqa
-from candig.pipeline_metadata_pb2 import * # noqa
-from candig.pipeline_metadata_service_pb2 import * # noqa
+from .candig.clinical_metadata_pb2 import *  # noqa
+from .candig.clinical_metadata_service_pb2 import *  # noqa
+from .candig.pipeline_metadata_pb2 import * # noqa
+from .candig.pipeline_metadata_service_pb2 import * # noqa
 
 # SEARCH
-from candig.search_service_pb2 import * # noqa
+from .candig.search_service_pb2 import * # noqa
 
-import candig.common_pb2 as common
+from . import candig.common_pb2 as common
 
-import hacks.googhack as googhack
+from . import hacks.googhack as googhack
+from functools import reduce
 
 MIMETYPES = [
     "application/json",
@@ -71,7 +72,7 @@ def setAttribute(values, value):
         values.add().int32_value = value
     elif isinstance(value, float):
         values.add().double_value = value
-    elif isinstance(value, long):
+    elif isinstance(value, int):
         values.add().int64_value = value
     elif isinstance(value, str):
         values.add().string_value = value

--- a/python/candig/schemas/protocol.py
+++ b/python/candig/schemas/protocol.py
@@ -2,9 +2,6 @@
 Definitions of the candig protocol types.
 """
 
-
-
-
 import datetime
 import json
 import inspect

--- a/python/candig/schemas/protocol.py
+++ b/python/candig/schemas/protocol.py
@@ -1,5 +1,5 @@
 """
-Definitions of the GA4GH protocol types.
+Definitions of the candig protocol types.
 """
 
 
@@ -12,41 +12,41 @@ import sys
 import array
 import base64
 
-from ._protocol_version import version  # noqa
-from .candig.common_pb2 import *  # noqa
-from .candig.metadata_pb2 import *  # noqa
-from .candig.metadata_service_pb2 import *  # noqa
-from .candig.read_service_pb2 import *  # noqa
-from .candig.reads_pb2 import *  # noqa
-from .candig.reference_service_pb2 import *  # noqa
-from .candig.references_pb2 import *  # noqa
-from .candig.variant_service_pb2 import *  # noqa
-from .candig.genotype_service_pb2 import *  # noqa
-from .candig.variants_pb2 import *  # noqa
-from .candig.allele_annotations_pb2 import *  # noqa
-from .candig.allele_annotation_service_pb2 import *  # noqa
-from .candig.sequence_annotations_pb2 import *  # noqa
-from .candig.sequence_annotation_service_pb2 import *  # noqa
-from .candig.bio_metadata_pb2 import *  # noqa
-from .candig.bio_metadata_service_pb2 import *  # noqa
-from .candig.genotype_phenotype_pb2 import *  # noqa
-from .candig.genotype_phenotype_service_pb2 import *  # noqa
-from .candig.rna_quantification_pb2 import *  # noqa
-from .candig.rna_quantification_service_pb2 import *  # noqa
-from .candig.peer_service_pb2 import *  # noqa
+from candig.schemas._protocol_version import version  # noqa
+from candig.schemas.candig.common_pb2 import *  # noqa
+from candig.schemas.candig.metadata_pb2 import *  # noqa
+from candig.schemas.candig.metadata_service_pb2 import *  # noqa
+from candig.schemas.candig.read_service_pb2 import *  # noqa
+from candig.schemas.candig.reads_pb2 import *  # noqa
+from candig.schemas.candig.reference_service_pb2 import *  # noqa
+from candig.schemas.candig.references_pb2 import *  # noqa
+from candig.schemas.candig.variant_service_pb2 import *  # noqa
+from candig.schemas.candig.genotype_service_pb2 import *  # noqa
+from candig.schemas.candig.variants_pb2 import *  # noqa
+from candig.schemas.candig.allele_annotations_pb2 import *  # noqa
+from candig.schemas.candig.allele_annotation_service_pb2 import *  # noqa
+from candig.schemas.candig.sequence_annotations_pb2 import *  # noqa
+from candig.schemas.candig.sequence_annotation_service_pb2 import *  # noqa
+from candig.schemas.candig.bio_metadata_pb2 import *  # noqa
+from candig.schemas.candig.bio_metadata_service_pb2 import *  # noqa
+from candig.schemas.candig.genotype_phenotype_pb2 import *  # noqa
+from candig.schemas.candig.genotype_phenotype_service_pb2 import *  # noqa
+from candig.schemas.candig.rna_quantification_pb2 import *  # noqa
+from candig.schemas.candig.rna_quantification_service_pb2 import *  # noqa
+from candig.schemas.candig.peer_service_pb2 import *  # noqa
 
 # METADATA
-from .candig.clinical_metadata_pb2 import *  # noqa
-from .candig.clinical_metadata_service_pb2 import *  # noqa
-from .candig.pipeline_metadata_pb2 import * # noqa
-from .candig.pipeline_metadata_service_pb2 import * # noqa
+from candig.schemas.candig.clinical_metadata_pb2 import *  # noqa
+from candig.schemas.candig.clinical_metadata_service_pb2 import *  # noqa
+from candig.schemas.candig.pipeline_metadata_pb2 import * # noqa
+from candig.schemas.candig.pipeline_metadata_service_pb2 import * # noqa
 
 # SEARCH
-from .candig.search_service_pb2 import * # noqa
+from candig.schemas.candig.search_service_pb2 import * # noqa
 
-from . import candig.common_pb2 as common
+import candig.schemas.candig.common_pb2 as common
 
-from . import hacks.googhack as googhack
+import candig.schemas.hacks.googhack as googhack
 from functools import reduce
 
 MIMETYPES = [

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-common==0.1.0
 #
-git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common
+git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-common==0.1.0
 #
-#git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
+git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-common==0.1.0
 #
-git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common
+# git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common

--- a/python/constraints.txt.default
+++ b/python/constraints.txt.default
@@ -23,4 +23,4 @@
 #
 # ga4gh-common==0.1.0
 #
-#git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common
+git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common

--- a/python/constraints.txt.default
+++ b/python/constraints.txt.default
@@ -23,4 +23,4 @@
 #
 # ga4gh-common==0.1.0
 #
-#git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
+#git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common

--- a/python/constraints.txt.default
+++ b/python/constraints.txt.default
@@ -24,4 +24,3 @@
 # ga4gh-common==0.1.0
 #
 # git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common
-

--- a/python/constraints.txt.default
+++ b/python/constraints.txt.default
@@ -23,4 +23,5 @@
 #
 # ga4gh-common==0.1.0
 #
-git+git://github.com/CanDIG/ga4gh-common.git@2to3#egg=ga4gh_common
+# git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common
+

--- a/python/dev_glue.py
+++ b/python/dev_glue.py
@@ -6,8 +6,5 @@ See __path__ documentation at:
     https://docs.python.org/2/tutorial/modules.html
 """
 
-
-
-
 import candig
 candig.__path__.insert(0, 'candig')

--- a/python/dev_glue.py
+++ b/python/dev_glue.py
@@ -5,9 +5,9 @@ Otherwise, python will look for schemas in the installed candig package.
 See __path__ documentation at:
     https://docs.python.org/2/tutorial/modules.html
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import candig
 candig.__path__.insert(0, 'candig')

--- a/python/dev_glue.py
+++ b/python/dev_glue.py
@@ -7,4 +7,4 @@ See __path__ documentation at:
 """
 
 import candig
-candig.__path__.insert(0, 'candig')
+candig.__path__.append('candig')

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,5 +3,5 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common
+candig-common
 protobuf==3.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,5 +3,5 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-# ga4gh-common
+candig-common
 protobuf==3.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,5 +3,5 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-ga4gh-common
+# ga4gh-common
 protobuf==3.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,5 +3,5 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-ga4gh-common==0.0.7
+ga4gh-common
 protobuf==3.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,5 +3,5 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-candig-common
+git+git://github.com/CanDIG/candig-common.git@master#egg=candig_common
 protobuf==3.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,6 @@
 # This file lists requirements needed to run the executables shipped
-# by ga4gh-schemas
+# by candig-schemas
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-candig-common
 protobuf==3.3.0

--- a/scripts/process_schemas.py
+++ b/scripts/process_schemas.py
@@ -156,11 +156,15 @@ class ProtobufGenerator(object):
                 os.path.realpath(source_path))
             raise Exception(msg)
 
+    # From https://stackoverflow.com/questions/22490366/how-to-use-cmp-in-python-3
+    def _cmp(self, a, b):
+        return (a > b) - (a < b) 
+
     # From http://stackoverflow.com/a/1714190/320546
     def _version_compare(self, version1, version2):
         def normalize(v):
             return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
-        return cmp(normalize(version1), normalize(version2))
+        return self._cmp(normalize(version1), normalize(version2))
 
     def _getProtoc(self, destination_path):
         protocs = [os.path.realpath(x) for x in
@@ -173,7 +177,7 @@ class ProtobufGenerator(object):
                 continue
             output = subprocess.check_output([c, "--version"]).strip()
             try:
-                (lib, version) = output.split(" ")
+                (lib, version) = output.decode('utf-8').split(" ")
                 if lib != "libprotoc":
                     raise Exception("lib didn't match 'libprotoc'")
                 if self._version_compare("3.0.0", version) > 0:

--- a/scripts/process_schemas.py
+++ b/scripts/process_schemas.py
@@ -156,9 +156,9 @@ class ProtobufGenerator(object):
                 os.path.realpath(source_path))
             raise Exception(msg)
 
-    # From https://stackoverflow.com/questions/22490366/how-to-use-cmp-in-python-3
+    # https://stackoverflow.com/questions/22490366/how-to-use-cmp-in-python-3
     def _cmp(self, a, b):
-        return (a > b) - (a < b) 
+        return (a > b) - (a < b)
 
     # From http://stackoverflow.com/a/1714190/320546
     def _version_compare(self, version1, version2):

--- a/scripts/process_schemas.py
+++ b/scripts/process_schemas.py
@@ -4,9 +4,6 @@ from a copy of the Protocol Buffers schema and use it to generate
 the Python class definitions. These are also stored in revision
 control to aid Travis building.
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import os.path
@@ -167,8 +164,8 @@ class ProtobufGenerator(object):
 
     def _getProtoc(self, destination_path):
         protocs = [os.path.realpath(x) for x in
-                   "{}/protobuf/src/protoc".format(destination_path),
-                   self._find_in_path("protoc")
+                   ("{}/protobuf/src/protoc".format(destination_path),
+                   self._find_in_path("protoc"))
                    if x is not None]
         protoc = None
         for c in protocs:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -5,12 +5,7 @@ Tests the schema compilation
 import os
 import tempfile
 import unittest
-
-# similar to dev_glue.py
-import candig
-candig.__path__.insert(0, 'python/candig')
-
-import candig.common.utils as utils  # NOQA
+import utils as utils  # NOQA
 import candig.schemas._version as version  # NOQA
 
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -2,9 +2,6 @@
 Tests the schema compilation
 """
 
-
-
-
 import os
 import tempfile
 import unittest

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -5,7 +5,7 @@ Tests the schema compilation
 import os
 import tempfile
 import unittest
-import utils as utils  # NOQA
+import utils
 import candig.schemas._version as version  # NOQA
 
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,9 +1,9 @@
 """
 Tests the schema compilation
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import os
 import tempfile

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -10,7 +10,7 @@ import unittest
 import candig
 candig.__path__.insert(0, 'python/candig')
 
-import ga4gh.common.utils as utils  # NOQA
+import candig.common.utils as utils  # NOQA
 import candig.schemas._version as version  # NOQA
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -2,9 +2,6 @@
 Tests the constraints invariants
 """
 
-
-
-
 import unittest
 
 import ga4gh.common.utils as utils

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -4,7 +4,7 @@ Tests the constraints invariants
 
 import unittest
 
-import ga4gh.common.utils as utils
+import candig.common.utils as utils
 
 
 class TestConstraints(unittest.TestCase):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -3,8 +3,7 @@ Tests the constraints invariants
 """
 
 import unittest
-
-import candig.common.utils as utils
+import utils as utils
 
 
 class TestConstraints(unittest.TestCase):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -3,7 +3,7 @@ Tests the constraints invariants
 """
 
 import unittest
-import utils as utils
+import utils
 
 
 class TestConstraints(unittest.TestCase):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,9 +1,9 @@
 """
 Tests the constraints invariants
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import unittest
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,9 @@
 """
 Tests for schemas
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import unittest
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,9 +2,6 @@
 Tests for schemas
 """
 
-
-
-
 import unittest
 
 # similar to dev_glue.py

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,13 +4,7 @@ Tests for schemas
 
 import unittest
 
-# similar to dev_glue.py
-import candig
-
-candig.__path__.insert(0, 'python/candig')
-
 import candig.schemas._protocol_version as version  # NOQA
-
 import candig.schemas.candig.common_pb2 as common_pb2  # NOQA
 import candig.schemas.candig.metadata_pb2 as metadata_pb2  # NOQA
 import candig.schemas.candig.metadata_service_pb2 as metadata_service_pb2  # NOQA

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import unittest
 
-import utils as utils
+import utils
 
 
 @unittest.skip("Disabled, unused")

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import unittest
 
-import ga4gh.common.utils as utils
+import candig.common.utils as utils
 
 
 class TestMaven(unittest.TestCase):

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -1,9 +1,9 @@
 """
 Runs the maven tests
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import shlex
 import subprocess

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -27,7 +27,7 @@ class TestMaven(unittest.TestCase):
     def runCommandCheckWarnings(self, cmd):
         utils.log("Running '{}'".format(cmd))
         splits = shlex.split(cmd)
-        output = subprocess.check_output(splits).split('\n')
+        output = subprocess.check_output(splits).decode('utf-8').split('\n')
         self.ensureNoWarnings(output, cmd)
 
     def ensureNoWarnings(self, lines, streamName):

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -6,9 +6,10 @@ import shlex
 import subprocess
 import unittest
 
-import candig.common.utils as utils
+import utils as utils
 
 
+@unittest.skip("Disabled, unused")
 class TestMaven(unittest.TestCase):
     """
     Uses maven to run tests

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -2,9 +2,6 @@
 Runs the maven tests
 """
 
-
-
-
 import shlex
 import subprocess
 import unittest

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2,9 +2,6 @@
 Tests for protocol.py
 """
 
-
-
-
 import datetime
 import unittest
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,9 +1,9 @@
 """
 Tests for protocol.py
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
 
 import datetime
 import unittest
@@ -46,9 +46,9 @@ class TestProtocol(unittest.TestCase):
         read = protocol.ReadAlignment()
         expected = "1"
         read.attributes.attr['key'].values.add().string_value = expected
-        tag, value = read.attributes.attr.items()[0]
+        tag, value = list(read.attributes.attr.items())[0]
         result = protocol.getValueFromValue(value.values[0])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def testToJsonAndFromJson(self):
         classes = protocol.getProtocolClasses()
@@ -96,7 +96,7 @@ class TestProtocol(unittest.TestCase):
     def testPostMethods(self):
         for postMethod in protocol.postMethods:
             self.assertEqual(len(postMethod), 3)
-            self.assertIsInstance(postMethod[0], unicode)
+            self.assertIsInstance(postMethod[0], str)
             self.assertTrue(issubclass(postMethod[1], message.Message))
             self.assertTrue(issubclass(postMethod[2], message.Message))
 
@@ -105,18 +105,18 @@ class TestProtocol(unittest.TestCase):
         read = protocol.ReadAlignment()
         values = read.attributes.attr['key'].values
         protocol.setAttribute(values, expected)
-        tag, value = read.attributes.attr.items()[0]
+        tag, value = list(read.attributes.attr.items())[0]
         result = value.values[0].int32_value
         self.assertEqual(result, expected)
 
     def testEncodeValue(self):
         expected = "5"
         result = protocol.encodeValue(expected)
-        self.assertEquals(result[0].string_value, expected)
+        self.assertEqual(result[0].string_value, expected)
         listExpected = ["5", "6"]
         listResult = protocol.encodeValue(listExpected)
-        self.assertEquals(listResult[0].string_value, listExpected[0])
-        self.assertEquals(listResult[1].string_value, listExpected[1])
+        self.assertEqual(listResult[0].string_value, listExpected[0])
+        self.assertEqual(listResult[1].string_value, listExpected[1])
 
     def testDeepGetAttr(self):
         class Object(object):
@@ -128,8 +128,8 @@ class TestProtocol(unittest.TestCase):
         obj = Object()
         setattr(obj, "a", a)
         setattr(obj, "d", 12)
-        self.assertEquals(protocol.deepGetAttr(obj, "a.b.c"), 42)
-        self.assertEquals(protocol.deepGetAttr(obj, "d"), 12)
+        self.assertEqual(protocol.deepGetAttr(obj, "a.b.c"), 42)
+        self.assertEqual(protocol.deepGetAttr(obj, "d"), 12)
         self.assertRaises(AttributeError,
                           protocol.deepGetAttr, obj, "a.b.x")
         self.assertRaises(AttributeError, protocol.deepGetAttr, obj, "e")
@@ -144,9 +144,9 @@ class TestProtocol(unittest.TestCase):
         obj = Object()
         setattr(obj, "a", a)
         protocol.deepSetAttr(obj, 'a.b.c', 43)
-        self.assertEquals(obj.a.b.c, 43)
+        self.assertEqual(obj.a.b.c, 43)
         protocol.deepSetAttr(obj, 'a.b.x', 12)
-        self.assertEquals(obj.a.b.x, 12)
+        self.assertEqual(obj.a.b.x, 12)
         self.assertRaises(AttributeError,
                           protocol.deepSetAttr, obj, "a.x.c", 42)
 
@@ -166,13 +166,13 @@ class TestRoundTrip(unittest.TestCase):
         dataset.description = description
         jsonStr = protocol.toJson(dataset)
         newDataset = protocol.fromJson(jsonStr, Dataset)
-        self.assertEquals(dataset.id, id_)
-        self.assertEquals(dataset.name, name)
-        self.assertEquals(dataset.description, description)
+        self.assertEqual(dataset.id, id_)
+        self.assertEqual(dataset.name, name)
+        self.assertEqual(dataset.description, description)
         datasetDict = protocol.toJsonDict(newDataset)
-        self.assertEquals(datasetDict['id'], id_)
-        self.assertEquals(datasetDict['name'], name)
-        self.assertEquals(datasetDict['description'], description)
+        self.assertEqual(datasetDict['id'], id_)
+        self.assertEqual(datasetDict['name'], name)
+        self.assertEqual(datasetDict['description'], description)
 
     def testRoundTripDatasetProtobufString(self):
         id_ = "id"
@@ -184,6 +184,6 @@ class TestRoundTrip(unittest.TestCase):
         dataset.description = description
         pbStr = protocol.toProtobufString(dataset)
         newDataset = protocol.fromProtobufString(pbStr, Dataset)
-        self.assertEquals(newDataset.id, id_)
-        self.assertEquals(newDataset.name, name)
-        self.assertEquals(newDataset.description, description)
+        self.assertEqual(newDataset.id, id_)
+        self.assertEqual(newDataset.name, name)
+        self.assertEqual(newDataset.description, description)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,345 @@
+"""
+Utilities used across many CanDIG packages
+"""
+import io
+import contextlib
+import fnmatch
+import functools
+import humanize
+import itertools
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import time
+import yaml
+
+
+def log(message):
+    """
+    Log a message
+    """
+    print(message)
+
+
+def getPathOfExecutable(executable):
+    """
+    Returns the full path of the executable, or None if the executable
+    can not be found.
+    """
+    exe_paths = os.environ['PATH'].split(':')
+    for exe_path in exe_paths:
+        exe_file = os.path.join(exe_path, executable)
+        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+            return exe_file
+    return None
+
+
+def requireExecutables(executables):
+    """
+    Check that all of the given executables are on the path.
+    If at least one of them is not, exit the script and inform
+    the user of the missing requirement(s).
+    """
+    missingExecutables = []
+    for executable in executables:
+        if getPathOfExecutable(executable) is None:
+            missingExecutables.append(executable)
+    if len(missingExecutables) > 0:
+        log("In order to run this script, the following "
+            "executables need to be on the path:")
+        for missingExecutable in missingExecutables:
+            log(missingExecutable)
+        exit(1)
+
+
+def runCommand(command, silent=False, shell=False):
+    """
+    Run a shell command
+    """
+    splits = shlex.split(command)
+    runCommandSplits(splits, silent=silent, shell=shell)
+
+
+def runCommandReturnOutput(cmd):
+    """
+    Runs a shell command and return the stdout and stderr
+    """
+    splits = shlex.split(cmd)
+    proc = subprocess.Popen(
+        splits, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(stdout, stderr)
+    return stdout, stderr
+
+
+def runCommandSplits(splits, silent=False, shell=False):
+    """
+    Run a shell command given the command's parsed command line
+    """
+    try:
+        if silent:
+            with open(os.devnull, 'w') as devnull:
+                subprocess.check_call(
+                    splits, stdout=devnull, stderr=devnull, shell=shell)
+        else:
+            subprocess.check_call(splits, shell=shell)
+    except OSError as exception:
+        if exception.errno == 2:  # cmd not found
+            raise Exception(
+                "Can't find command while trying to run {}".format(splits))
+        else:
+            raise
+
+
+def getAuthValues(filePath='scripts/auth.yml'):
+    """
+    Return the script authentication file as a dictionary
+    """
+    return getYamlDocument(filePath)
+
+
+def getYamlDocument(filePath):
+    """
+    Return a yaml file's contents as a dictionary
+    """
+    with open(filePath) as stream:
+        doc = yaml.load(stream)
+        return doc
+
+
+def captureOutput(func, *args, **kwargs):
+    """
+    Runs the specified function and arguments, and returns the
+    tuple (stdout, stderr) as strings.
+    """
+    stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        func(*args, **kwargs)
+        stdoutOutput = sys.stdout.getvalue()
+        stderrOutput = sys.stderr.getvalue()
+    finally:
+        sys.stdout.close()
+        sys.stdout = stdout
+        sys.stderr.close()
+        sys.stderr = stderr
+    return stdoutOutput, stderrOutput
+
+
+def zipLists(*lists):
+    """
+    Checks to see if all of the lists are the same length, and throws
+    an AssertionError otherwise.  Returns the zipped lists.
+    """
+    length = len(lists[0])
+    for i, list_ in enumerate(lists[1:]):
+        if len(list_) != length:
+            msg = "List at index {} has length {} != {}".format(
+                i + 1, len(list_), length)
+            raise AssertionError(msg)
+    return list(zip(*lists))
+
+
+def getLinesFromLogFile(stream):
+    """
+    Returns all lines written to the passed in stream
+    """
+    stream.flush()
+    stream.seek(0)
+    lines = stream.readlines()
+    return lines
+
+
+def powerset(iterable, maxSets=None):
+    """
+    powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
+
+    See https://docs.python.org/2/library/itertools.html#recipes
+    """
+    s = list(iterable)
+    return itertools.islice(itertools.chain.from_iterable(
+        itertools.combinations(s, r) for r in range(len(s) + 1)),
+        0, maxSets)
+
+
+def chomp(line):
+    """
+    Returns a string stripped of its trailing newline character
+    """
+    assert line[-1] == '\n'
+    return line[:-1]
+
+
+def getFilePathsWithExtensionsInDirectory(dirTree, patterns, sort=True):
+    """
+    Returns all file paths that match any one of patterns in a
+    file tree with its root at dirTree.  Sorts the paths by default.
+    """
+    filePaths = []
+    for root, dirs, files in os.walk(dirTree):
+        for filePath in files:
+            for pattern in patterns:
+                if fnmatch.fnmatch(filePath, pattern):
+                    fullPath = os.path.join(root, filePath)
+                    filePaths.append(fullPath)
+                    break
+    if sort:
+        filePaths.sort()
+    return filePaths
+
+
+def touch(filepath):
+    """
+    Creates an empty file at filepath, if it does not already exist
+    """
+    with open(filepath, 'a'):
+        pass
+
+
+def assertFileContentsIdentical(pathOne, pathTwo):
+    with open(pathOne) as fileOne, open(pathTwo) as fileTwo:
+        for i, (lineOne, lineTwo) in enumerate(zip(fileOne, fileTwo)):
+            if lineOne != lineTwo:
+                msg = "Mismatch on line {}: '{}' != '{}'".format(
+                    i + 1, lineOne, lineTwo)
+                raise AssertionError(msg)
+        # one file could have more lines than the other file
+        extraLine = fileOne.readline()
+        if extraLine:
+            msg = "File one has extra line: '{}'".format(extraLine)
+            raise AssertionError(msg)
+        extraLine = fileTwo.readline()
+        if extraLine:
+            msg = "File two has extra line: '{}'".format(extraLine)
+            raise AssertionError(msg)
+
+
+# ---------------- Decorators ----------------
+
+
+class TimeoutException(Exception):
+    """
+    A process has taken too long to execute
+    """
+
+
+class Timed(object):
+    """
+    Decorator that times a method, reporting runtime at finish
+    """
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            self.start = time.time()
+            result = func(*args, **kwargs)
+            self.end = time.time()
+            self._report()
+            return result
+        return wrapper
+
+    def _report(self):
+        delta = self.end - self.start
+        timeString = humanize.time.naturaldelta(delta)
+        log("Finished in {} ({:.2f} seconds)".format(timeString, delta))
+
+
+class Repeat(object):
+    """
+    A decorator to use for repeating a tagged function.
+    The tagged function should return true if it wants to run again,
+    and false if it wants to stop repeating.
+    """
+    defaultSleepSeconds = 0.1
+
+    def __init__(self, sleepSeconds=defaultSleepSeconds):
+        self.sleepSeconds = sleepSeconds
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            while func(*args, **kwargs):
+                time.sleep(self.sleepSeconds)
+        return wrapper
+
+
+class Timeout(object):
+    """
+    A decorator to use for only allowing a function to run
+    for a limited amount of time
+    """
+    defaultTimeoutSeconds = 60
+
+    def __init__(self, timeoutSeconds=defaultTimeoutSeconds):
+        self.timeoutSeconds = timeoutSeconds
+
+    def __call__(self, func):
+
+        def _handle_timeout(signum, frame):
+            raise TimeoutException()
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                # set the alarm and execute func
+                signal.signal(signal.SIGALRM, _handle_timeout)
+                signal.alarm(self.timeoutSeconds)
+                result = func(*args, **kwargs)
+            finally:
+                # clear the alarm
+                signal.alarm(0)
+            return result
+        return wrapper
+
+
+# ---------------- Context managers ----------------
+
+
+@contextlib.contextmanager
+def suppressOutput():
+    # I would like to use sys.stdout.fileno() and sys.stderr.fileno()
+    # here instead of literal fd numbers, but nose does something like
+    # sys.stdout = StringIO.StringIO() when the -s flag is not enabled
+    # (to capture test output so it doesn't get entangled with nose's
+    # display) so the sys.stdout and sys.stderr objects are not able to
+    # be accessed here.
+    try:
+        # redirect stdout and stderr to /dev/null
+        devnull = open(os.devnull, 'w')
+        origStdoutFd = 1
+        origStderrFd = 2
+        origStdout = os.dup(origStdoutFd)
+        origStderr = os.dup(origStderrFd)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(devnull.fileno(), origStdoutFd)
+        os.dup2(devnull.fileno(), origStderrFd)
+        # enter the wrapped code
+        yield
+    finally:
+        # restore original file streams
+        devnull.flush()
+        os.dup2(origStdout, origStdoutFd)
+        os.dup2(origStderr, origStderrFd)
+        # clean up
+        os.close(origStdout)
+        os.close(origStderr)
+        devnull.close()
+
+
+@contextlib.contextmanager
+def performInDirectory(dirPath):
+    """
+    Change the current working directory to dirPath before performing
+    an operation, then restore the original working directory after
+    """
+    originalDirectoryPath = os.getcwd()
+    try:
+        os.chdir(dirPath)
+        yield
+    finally:
+        os.chdir(originalDirectoryPath)

--- a/tools/sphinx/protobuf-json-docs.py
+++ b/tools/sphinx/protobuf-json-docs.py
@@ -53,7 +53,7 @@ def convert_protodef_to_editable(proto):
                 self.input_type = prot.input_type
                 self.output_type = prot.output_type
             else:
-                raise Exception, type(prot)
+                raise Exception(type(prot))
 
     return Editable(proto)
 
@@ -95,7 +95,7 @@ def traverse(proto_file):
                             if method_comment != {}:
                                 item.method[k].comment = _collapse_comments(method_comment)
                 else:
-                    raise Exception, item.kind
+                    raise Exception(item.kind)
 
             yield item, package
 
@@ -114,7 +114,7 @@ def traverse(proto_file):
         if loc.leading_comments or loc.trailing_comments:
             place = tree
             for p in loc.path:
-                if not place.has_key(p):
+                if p not in place:
                     place[p] = collections.defaultdict(collections.defaultdict)
                 place = place[p]
             place["leading_comments"] = loc.leading_comments
@@ -122,7 +122,7 @@ def traverse(proto_file):
     
     # Only message, services, enums, extensions, options
     if set(tree.keys()).difference(set([4, 5, 6, 7, 8])) != set():
-        raise Exception, tree
+        raise Exception(tree)
 
     return {"types":
         list(itertools.chain(
@@ -185,7 +185,7 @@ def type_to_string(f, map_types):
     elif f.type in [18]:
         return "sint64"
     else:
-        raise Exception, f.type
+        raise Exception(f.type)
 
 def generate_code(request, response):
     """
@@ -201,7 +201,7 @@ def generate_code(request, response):
         def full_name(package, item):
             return "%s.%s" % (package, item.name)
         for item, package in results["types"]:
-            if item.options.has_key("map_entry"):
+            if "map_entry" in item.options:
                 map_types[full_name(package, item)] = dict([(x.name,x) for x in item.field])
         for item, package in results["types"]:
             name = full_name(package, item)
@@ -252,7 +252,7 @@ def generate_code(request, response):
                         "errors" : [ ":protobuf:message:`GAException`" ]
                     }
             else:
-                raise Exception, item.kind
+                raise Exception(item.kind)
 
         comments = "\n".join(results["file"])
         output = {

--- a/tools/sphinx/protobuf-uml.py
+++ b/tools/sphinx/protobuf-uml.py
@@ -134,7 +134,7 @@ def write_graph(fields, containments, nests, matched_references, clusters):
     graph += "]\n\n"
 
     # Draw each node/type/record as a table
-    for type_name, field_list in list(fields.items()):
+    for type_name, field_list in fields.items():
 
         graph += "{} [label=<\n".format(type_name)
         graph += "<TABLE BORDER='0' CELLBORDER='1' CELLSPACING='0' CELLPADDING='4' bgcolor='#002060' color='#002060'>\n"
@@ -166,7 +166,7 @@ def write_graph(fields, containments, nests, matched_references, clusters):
         graph += "</TABLE>>];\n\n"
 
     # Now define the clusters/subgraphs
-    for cluster_name, cluster_types in list(clusters.items()):
+    for cluster_name, cluster_types in clusters.items():
         graph += "subgraph cluster_{} {{\n".format(cluster_name.replace(".", "_").replace("/", "_"))
         graph += "\tstyle=\"rounded, filled\";\n"
         graph += "\tcolor=lightgrey;\n"

--- a/tools/sphinx/protobuf-uml.py
+++ b/tools/sphinx/protobuf-uml.py
@@ -134,7 +134,7 @@ def write_graph(fields, containments, nests, matched_references, clusters):
     graph += "]\n\n"
 
     # Draw each node/type/record as a table
-    for type_name, field_list in fields.items():
+    for type_name, field_list in list(fields.items()):
 
         graph += "{} [label=<\n".format(type_name)
         graph += "<TABLE BORDER='0' CELLBORDER='1' CELLSPACING='0' CELLPADDING='4' bgcolor='#002060' color='#002060'>\n"
@@ -166,7 +166,7 @@ def write_graph(fields, containments, nests, matched_references, clusters):
         graph += "</TABLE>>];\n\n"
 
     # Now define the clusters/subgraphs
-    for cluster_name, cluster_types in clusters.items():
+    for cluster_name, cluster_types in list(clusters.items()):
         graph += "subgraph cluster_{} {{\n".format(cluster_name.replace(".", "_").replace("/", "_"))
         graph += "\tstyle=\"rounded, filled\";\n"
         graph += "\tcolor=lightgrey;\n"

--- a/tools/sphinx/protodoc2rst.py
+++ b/tools/sphinx/protodoc2rst.py
@@ -26,9 +26,9 @@ def typename(typeobject):
     elif typeobject['type'] == 'map':
       return 'map<%s, %s>' % (typename(typeobject['key']), typename(typeobject['value']))
     else:
-      raise Exception, "Unsupported type object: %s" %(typeobject['type'])
+      raise Exception("Unsupported type object: %s" %(typeobject['type']))
 
-  elif isinstance(typeobject, basestring):
+  elif isinstance(typeobject, str):
     return typeobject
 
   raise ValueError


### PR DESCRIPTION
This PR introduces

- The upgraded codebase, runnable in Python 3.6+
- The removal of candig-common from its dependencies. Complications occurred since the source code lives under /python, which needs a manual overwrite under setup.py (in `package_dir`); This makes it very difficult to import candig-common as in `candig.common`, due to the fact that they share a primary namespace. To resolve this issue, a module, `utils.py` is copied from candig-common to the `tests` directory. It will not be part of the standard distribution, so won't increase our distribution size. As a result, `candig-common` is also removed.
- The removal of the maven test suite. It is of no use.